### PR TITLE
fixed itGenerator for double-quote in values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 testSuite
+examples

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # kandinskijs-test-generator
+
+
+## How-to
+
+You can run the test generator against your CSS file through this command:
+
+`./node_modules/.bin/cross-env CSS_PATH=examples/base.css node demo/demo-index.js`
+
+You can then run the testSuite generated via:
+
+`./node_modules/.bin/mocha testSuite/*.js`

--- a/demo/demo-index.js
+++ b/demo/demo-index.js
@@ -1,4 +1,7 @@
 const generator = require("../src/kGenerator");
 
-generator.init("demo/demo.css");
+const CSS_PATH = process.env.CSS_PATH || "demo/base.css";
+const OUT_DIR = process.env.OUT_DIR || "testSuite";
+generator.init(CSS_PATH, OUT_DIR);
 generator.generateTest();
+console.log(`Created tests for '${CSS_PATH}' in '${OUT_DIR}'`);

--- a/src/utilities/itGenerator.js
+++ b/src/utilities/itGenerator.js
@@ -1,37 +1,43 @@
-var fs = require("fs");
-
 module.exports = function (stream) {
-	var generatePxIt = function (itClass) {
-		var it = `it("${itClass.selector} should have a ${itClass.property}: ${itClass.value}", async function() {
-		const selector = "${itClass.selector}";
+  var sanitizeQuotes = function (value) {
+    value = value || "";
+    return value.replace(/"/gi, '\\"');
+  };
+  var generatePxIt = function (itClass) {
+    const sanitizedValue = sanitizeQuotes(itClass.value);
+    const sanitizedSelector = sanitizeQuotes(itClass.selector);
+    var it = `it("${sanitizedSelector} should have a ${itClass.property}: ${sanitizedValue}", async function() {
+		const selector = "${sanitizedSelector}";
 		const cssProperty = "${itClass.property}";
 		const val = await kisk.getCSSProperty(page, selector, cssProperty);
 
-		expect(val).to.eql("${itClass.value}");
+		expect(val).to.eql("${sanitizedValue}");
 });\n\r`;
-		stream.write(it);
-	};
+    stream.write(it);
+  };
 
-	var generatePctIt = function (itClass) {
-		var it = `it("${itClass.selector} should have a ${itClass.property}: ${itClass.value}", async function() {
-		const selector = "${itClass.selector}";
+  var generatePctIt = function (itClass) {
+    const sanitizedValue = sanitizeQuotes(itClass.value);
+    const sanitizedSelector = sanitizeQuotes(itClass.selector);
+    var it = `it("${sanitizedSelector} should have a ${itClass.property}: ${sanitizedValue}", async function() {
+		const selector = "${sanitizedSelector}";
 		const cssProperty = "${itClass.property}";
 		const val = await kisk.getPctCSSProperty(page, selector, cssProperty);
 
-		expect(val).to.eql("${itClass.value}");
+		expect(val).to.eql("${sanitizedValue}");
 });\n\r`;
-		stream.write(it);
-	};
+    stream.write(it);
+  };
 
-	return {
-		generateIt: function (itClass) {
-			if (itClass.valueType == "px") {
-				generatePxIt(itClass);
-			}
+  return {
+    generateIt: function (itClass) {
+      if (itClass.valueType == "px") {
+        generatePxIt(itClass);
+      }
 
-			if (itClass.valueType == "perc") {
-				generatePctIt(itClass);
-			}
-		}
-	}
+      if (itClass.valueType == "perc") {
+        generatePctIt(itClass);
+      }
+    },
+  };
 };


### PR DESCRIPTION
- Fixed itGenerator to manage values and selectors which may contain double quotes.
- Reviewed demo.js to allow env variables for samples usage
- Added simple README.md file